### PR TITLE
Add interactive homepage/editor demo to UI examples

### DIFF
--- a/packages/ui/examples/index.css
+++ b/packages/ui/examples/index.css
@@ -1,0 +1,266 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top, #0f172a, #020617 55%);
+  color: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at top, rgba(15, 23, 42, 0.95), rgba(2, 6, 23, 0.95) 55%);
+  padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+#app {
+  width: 100%;
+}
+
+.demo-shell {
+  width: min(1040px, 100%);
+  background: rgba(15, 23, 42, 0.92);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 40px 85px rgba(8, 15, 45, 0.35);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.demo-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding: clamp(1.75rem, 3vw, 2.75rem) clamp(1.75rem, 4vw, 3rem);
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.55), rgba(76, 29, 149, 0.35));
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.demo-header__eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.25em;
+  opacity: 0.75;
+  margin-bottom: 0.35rem;
+}
+
+.demo-header__title {
+  margin: 0;
+  font-size: clamp(1.85rem, 4vw, 2.65rem);
+  line-height: 1.2;
+}
+
+.demo-header__subtitle {
+  margin: 0.35rem 0 0;
+  max-width: 32rem;
+  color: rgba(226, 232, 240, 0.78);
+  font-size: clamp(0.95rem, 2.5vw, 1.05rem);
+  line-height: 1.6;
+}
+
+.demo-tabs {
+  display: inline-flex;
+  padding: 0.35rem;
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  gap: 0.35rem;
+}
+
+.demo-tab {
+  appearance: none;
+  border: 0;
+  padding: 0.55rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  color: rgba(226, 232, 240, 0.75);
+  background: transparent;
+  transition: background 140ms ease, color 140ms ease, transform 140ms ease;
+}
+
+.demo-tab:is(:hover, :focus-visible) {
+  background: rgba(148, 163, 184, 0.18);
+  color: #f8fafc;
+  outline: none;
+}
+
+.demo-tab.is-active {
+  background: linear-gradient(120deg, #38bdf8, #a855f7 70%, #f97316 100%);
+  color: #0f172a;
+  box-shadow: 0 10px 25px rgba(56, 189, 248, 0.25);
+}
+
+.demo-content {
+  padding: clamp(1.75rem, 4vw, 3rem);
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.home-hero {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.home-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.demo-button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.7rem 1.45rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: transform 140ms ease, box-shadow 140ms ease, background 140ms ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  text-decoration: none;
+}
+
+.demo-button--primary {
+  background: linear-gradient(120deg, #38bdf8, #a855f7 70%, #f97316 100%);
+  color: #0f172a;
+  box-shadow: 0 16px 32px rgba(56, 189, 248, 0.35);
+}
+
+.demo-button--secondary {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.demo-button:is(:hover, :focus-visible) {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(56, 189, 248, 0.32);
+  outline: none;
+}
+
+.home-features {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.feature-card {
+  background: rgba(15, 23, 42, 0.88);
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 1.4rem 1.6rem;
+  display: grid;
+  gap: 0.65rem;
+  transition: transform 160ms ease, border 160ms ease;
+}
+
+.feature-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.feature-card__title {
+  font-size: 1.15rem;
+  margin: 0;
+  color: #f8fafc;
+}
+
+.feature-card__description {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.7);
+  line-height: 1.6;
+}
+
+.editor-shell {
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 2rem);
+}
+
+.editor-grid {
+  display: grid;
+  gap: clamp(1rem, 3vw, 1.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.editor-panel {
+  background: rgba(15, 23, 42, 0.88);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  display: grid;
+  gap: 0.85rem;
+}
+
+.editor-textarea {
+  width: 100%;
+  min-height: clamp(260px, 40vh, 380px);
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  padding: 1.1rem 1.25rem;
+  background: rgba(15, 23, 42, 0.95);
+  color: inherit;
+  font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, "Menlo", monospace;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  resize: vertical;
+}
+
+.editor-textarea:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.65);
+  outline-offset: 2px;
+}
+
+.editor-preview {
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: rgba(226, 232, 240, 0.78);
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 1rem 1.25rem;
+}
+
+.editor-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  color: rgba(226, 232, 240, 0.6);
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 1rem;
+  }
+
+  .demo-header {
+    align-items: flex-start;
+  }
+
+  .demo-header__subtitle {
+    max-width: none;
+  }
+
+  .editor-footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/packages/ui/examples/index.html
+++ b/packages/ui/examples/index.html
@@ -5,7 +5,8 @@
     <meta name="viewport"
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Document</title>
+    <title>Logseq UI Playground</title>
+    <link rel="stylesheet" href="./index.css">
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="./index.tsx" type="module"></script>

--- a/packages/ui/examples/index.tsx
+++ b/packages/ui/examples/index.tsx
@@ -1,26 +1,190 @@
-import '../src/index.css'
+import './index.css'
 import { setupGlobals } from '../src/ui'
 import * as React from 'react'
-import * as ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 
-// @ts-ignore
-import { Button } from '@/components/ui/button'
+type View = 'home' | 'editor'
 
-// bootstrap
+type Feature = {
+  title: string
+  description: string
+}
+
+type DemoButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'primary' | 'secondary'
+}
+
 setupGlobals()
 
-function App() {
+const features: Feature[] = [
+  {
+    title: 'Powerful knowledge graph',
+    description:
+      'Link your ideas bidirectionally, surface backlinks instantly, and keep every concept connected across your graph.',
+  },
+  {
+    title: 'Offline-first by design',
+    description:
+      'Your notes live on your device. Sync to the cloud only when you choose to and keep ownership of your knowledge.',
+  },
+  {
+    title: 'Custom workflows',
+    description:
+      'Capture tasks, track meetings, and publish public pages with extensible plugins and a thriving community.',
+  },
+]
+
+const DEFAULT_NOTE = `# Daily journal\n\n- [ ] Capture three highlights from today\n- [ ] Plan tomorrow's priorities\n- 💡 Draft a new plugin idea for sharing pages\n\n> Tip: Use \`[[Links]]\` and \`#tags\` to connect thoughts as you write.`
+
+const DemoButton = React.forwardRef<HTMLButtonElement, DemoButtonProps>(
+  ({ variant = 'primary', className = '', ...props }, ref) => (
+    <button
+      ref={ref}
+      className={`demo-button demo-button--${variant} ${className}`.trim()}
+      {...props}
+    />
+  )
+)
+DemoButton.displayName = 'DemoButton'
+
+interface HomePageProps {
+  onOpenEditor: () => void
+}
+
+function HomePage({ onOpenEditor }: HomePageProps) {
   return (
-    <main className={'p-8'}>
-      <h1 className={'text-red-500 mb-8'}>
-        Hello, Logseq UI :)
-      </h1>
-      <Button asChild>
-        <a href={'https://google.com'} target={'_blank'}>go to google.com</a>
-      </Button>
-    </main>
+    <section className="home-hero" aria-labelledby="home-title">
+      <header>
+        <h2 id="home-title">Welcome to Logseq</h2>
+        <p>
+          Craft delightful knowledge bases, share ideas with your team, and keep your notes close — all from the browser
+          preview below.
+        </p>
+        <div className="home-hero__actions">
+          <DemoButton onClick={onOpenEditor}>Open the editor demo</DemoButton>
+          <a
+            className="demo-button demo-button--secondary"
+            href="https://logseq.com"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Visit logseq.com
+          </a>
+        </div>
+      </header>
+      <div className="home-features">
+        {features.map((feature) => (
+          <article key={feature.title} className="feature-card">
+            <h3 className="feature-card__title">{feature.title}</h3>
+            <p className="feature-card__description">{feature.description}</p>
+          </article>
+        ))}
+      </div>
+    </section>
   )
 }
 
-// mount app
-ReactDOM.render(<App/>, document.querySelector('#app'))
+function EditorPlayground() {
+  const [note, setNote] = React.useState(DEFAULT_NOTE)
+
+  const stats = React.useMemo(() => {
+    const trimmed = note.trim()
+    const words = trimmed.length > 0 ? trimmed.split(/\s+/).length : 0
+    const characters = note.length
+    const lines = note.split(/\r?\n/).length
+
+    return { words, characters, lines }
+  }, [note])
+
+  return (
+    <section className="editor-shell" aria-labelledby="editor-title">
+      <header>
+        <h2 id="editor-title">Editor playground</h2>
+        <p>
+          Try the lightweight Markdown editor. Reset the sample content, track your word count, and preview formatted text
+          in real time.
+        </p>
+      </header>
+      <div className="editor-grid">
+        <div className="editor-panel">
+          <h3>Markdown note</h3>
+          <textarea
+            aria-label="Editor input"
+            className="editor-textarea"
+            value={note}
+            onChange={(event) => setNote(event.target.value)}
+          />
+          <div className="home-hero__actions">
+            <DemoButton onClick={() => setNote(DEFAULT_NOTE)}>Reset content</DemoButton>
+          </div>
+        </div>
+        <div className="editor-panel">
+          <h3>Live preview</h3>
+          <div className="editor-preview" aria-live="polite">
+            {note.trim().length === 0 ? 'Start typing to see your note preview.' : note}
+          </div>
+          <footer className="editor-footer">
+            <span>
+              {stats.lines.toLocaleString()} {stats.lines === 1 ? 'line' : 'lines'}
+            </span>
+            <span>
+              {stats.words.toLocaleString()} {stats.words === 1 ? 'word' : 'words'}
+            </span>
+            <span>
+              {stats.characters.toLocaleString()} {stats.characters === 1 ? 'character' : 'characters'}
+            </span>
+          </footer>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function App() {
+  const [view, setView] = React.useState<View>('home')
+
+  return (
+    <div className="demo-shell">
+      <header className="demo-header">
+        <div>
+          <p className="demo-header__eyebrow">Logseq components</p>
+          <h1 className="demo-header__title">Interface playground</h1>
+          <p className="demo-header__subtitle">
+            Explore the marketing homepage and the editor preview without leaving this Typescript-powered demo.
+          </p>
+        </div>
+        <div className="demo-tabs" role="tablist" aria-label="Select demo view">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === 'home'}
+            className={`demo-tab ${view === 'home' ? 'is-active' : ''}`.trim()}
+            onClick={() => setView('home')}
+          >
+            Homepage
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === 'editor'}
+            className={`demo-tab ${view === 'editor' ? 'is-active' : ''}`.trim()}
+            onClick={() => setView('editor')}
+          >
+            Editor
+          </button>
+        </div>
+      </header>
+      <div className="demo-content">
+        {view === 'home' ? <HomePage onOpenEditor={() => setView('editor')} /> : <EditorPlayground />}
+      </div>
+    </div>
+  )
+}
+
+const rootElement = document.querySelector('#app')
+
+if (!rootElement) {
+  throw new Error('Failed to find the root element for the Logseq UI demo.')
+}
+
+createRoot(rootElement as HTMLElement).render(<App />)


### PR DESCRIPTION
## Summary
- replace the UI example entry point with a React 18 app that switches between homepage and editor demos
- add rich styling and layout for the demo shell, hero, feature cards, and editor preview
- update the HTML example to load the new stylesheet and modern title

## Testing
- `bb dev:lint-and-test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b1f52f948320ad9c5d71d2a3f445